### PR TITLE
fixes for tcl8.6, 64bit-problem and HTML5 attributes

### DIFF
--- a/generic/domxslt.c
+++ b/generic/domxslt.c
@@ -2679,7 +2679,7 @@ static int fastMergeSort (
         }
     }
     memcpy(a,    b,     size*sizeof(domNode*));
-    memcpy(posa, posb,  size*sizeof(int*));
+    memcpy(posa, posb,  size*sizeof(int));
     memcpy(vs,   vstmp, size*sizeof(char*));
     memcpy(vd,   vdtmp, size*sizeof(double));
     return 0;

--- a/generic/tcldom.c
+++ b/generic/tcldom.c
@@ -2424,6 +2424,107 @@ void tcldom_tolower (
 |   tcldom_treeAsHTML
 |
 \---------------------------------------------------------------------------*/
+int tcldom_isBooleanAttributeHTML (
+    const char *tag,
+    const char *attrName
+)
+{
+  return (
+      (tag[0] == 'b' && !strcmp(tag,"button")
+       && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
+	   (attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
+	   (attrName[0] == 'f' && !strcmp(attrName,"formnovalidate"))
+	   )) ||
+      
+      (tag[0] == 'c' && !strcmp(tag,"command")
+       && ((attrName[0] == 'c' && !strcmp(attrName,"checked")) ||
+	   (attrName[0] == 'd' && !strcmp(attrName,"disabled"))
+	   )) ||
+      
+      (tag[0] == 'f' && !strcmp(tag,"form")
+       && ((attrName[0] == 'n' && !strcmp(attrName,"novalidate"))
+	   )) ||
+      
+      (tag[0] == 'i' && !strcmp(tag,"img")
+       && ((attrName[0] == 'i' && !strcmp(attrName,"ismap"))
+	   )) ||
+      
+      (tag[0] == 'i' && !strcmp(tag,"iframe")
+       && ((attrName[0] == 's' && !strcmp(attrName,"seamless"))
+	   )) ||
+      
+      (tag[0] == 'i' && !strcmp(tag,"input")
+       && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
+	   (attrName[0] == 'c' && !strcmp(attrName,"checked")) ||
+	   (attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
+	   (attrName[0] == 'f' && !strcmp(attrName,"formnovalidate")) ||
+	   (attrName[0] == 'm' && !strcmp(attrName,"multiple")) ||
+	   (attrName[0] == 'r' && !strcmp(attrName,"readonly")) ||
+	   (attrName[0] == 'r' && !strcmp(attrName,"required"))
+	   )) ||
+      
+      (tag[0] == 'k' && !strcmp(tag,"keygen")
+       && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
+	   (attrName[0] == 'd' && !strcmp(attrName,"disabled"))
+	   )) ||
+      
+      (tag[0] == 'o' && !strcmp(tag,"ol")
+       && ((attrName[0] == 'r' && !strcmp(attrName,"reversed"))
+	   )) ||
+      
+      (tag[0] == 'o' && !strcmp(tag,"optgroup")
+       && ((attrName[0] == 'd' && !strcmp(attrName,"disabled"))
+	   )) ||
+      
+      (tag[0] == 'o' && !strcmp(tag,"option")
+       && ((attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
+	   (attrName[0] == 's' && !strcmp(attrName,"selected"))
+	   )) ||
+      
+      (tag[0] == 's' && !strcmp(tag,"script")
+       && ((attrName[0] == 'a' && !strcmp(attrName,"async")) ||
+	   (attrName[0] == 'd' && !strcmp(attrName,"defer"))
+	   )) ||
+      
+      (tag[0] == 's' && !strcmp(tag,"select")
+       && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
+	   (attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
+	   (attrName[0] == 'm' && !strcmp(attrName,"multiple")) ||
+	   (attrName[0] == 'r' && !strcmp(attrName,"required"))
+	   )) ||
+      
+      (tag[0] == 's' && !strcmp(tag,"style")
+       && ((attrName[0] == 's' && !strcmp(attrName,"scoped"))
+	   )) ||
+      
+      (tag[0] == 't' && !strcmp(tag,"textarea")
+       && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
+	   (attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
+	   (attrName[0] == 'r' && !strcmp(attrName,"readonly")) ||
+	   (attrName[0] == 'r' && !strcmp(attrName,"required"))
+	   )) ||
+      
+      (tag[0] == 't' && !strcmp(tag,"time")
+       && ((attrName[0] == 'p' && !strcmp(attrName,"pubdate"))
+	   )) ||
+      
+      (tag[0] == 'a' && !strcmp(tag,"audio")
+       && ((attrName[0] == 'a' && !strcmp(attrName,"autoplay")) ||
+	   (attrName[0] == 'c' && !strcmp(attrName,"controls")) ||
+	   (attrName[0] == 'l' && !strcmp(attrName,"loop"))
+	   )) ||
+      (tag[0] == 'v' && !strcmp(tag,"video")
+       && ((attrName[0] == 'a' && !strcmp(attrName,"autoplay")) ||
+	   (attrName[0] == 'c' && !strcmp(attrName,"controls")) ||
+	   (attrName[0] == 'l' && !strcmp(attrName,"loop"))
+	   ))
+	  );
+}
+
+/*----------------------------------------------------------------------------
+|   tcldom_treeAsHTML
+|
+\---------------------------------------------------------------------------*/
 static
 void tcldom_treeAsHTML (
     Tcl_Obj     *htmlString,
@@ -2559,110 +2660,20 @@ void tcldom_treeAsHTML (
 
     attrs = node->firstAttr;
     while (attrs) {
-        int writeAttrName = 1;
-        int writeAttrValue = 1;
+        int writeAttrName, writeAttrValue;
+
         tcldom_tolower(attrs->nodeName, attrName, 80);
         writeChars(htmlString, chan, " ", 1);
 
-	fprintf(stderr, "=== we have tag %s and attr %s\n",tag,attrName);
-
-	if (
-	    (tag[0] == 'b' && !strcmp(tag,"button")
-	    && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
-		(attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
-		(attrName[0] == 'f' && !strcmp(attrName,"formnovalidate"))
-		)) ||
-
-	    (tag[0] == 'c' && !strcmp(tag,"command")
-	    && ((attrName[0] == 'c' && !strcmp(attrName,"checked")) ||
-		(attrName[0] == 'd' && !strcmp(attrName,"disabled"))
-		)) ||
-
-	    (tag[0] == 'f' && !strcmp(tag,"form")
-	    && ((attrName[0] == 'n' && !strcmp(attrName,"novalidate"))
-		)) ||
-
-	    (tag[0] == 'i' && !strcmp(tag,"img")
-	    && ((attrName[0] == 'i' && !strcmp(attrName,"ismap"))
-		)) ||
-
-	    (tag[0] == 'i' && !strcmp(tag,"iframe")
-	    && ((attrName[0] == 's' && !strcmp(attrName,"seamless"))
-		)) ||
-
-	    (tag[0] == 'i' && !strcmp(tag,"input")
-	     && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
-		 (attrName[0] == 'c' && !strcmp(attrName,"checked")) ||
-		 (attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
-		 (attrName[0] == 'f' && !strcmp(attrName,"formnovalidate")) ||
-		 (attrName[0] == 'm' && !strcmp(attrName,"multiple")) ||
-		 (attrName[0] == 'r' && !strcmp(attrName,"readonly")) ||
-		 (attrName[0] == 'r' && !strcmp(attrName,"required"))
-		 )) ||
-
-	    (tag[0] == 'k' && !strcmp(tag,"keygen")
-	     && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
-		 (attrName[0] == 'd' && !strcmp(attrName,"disabled"))
-		 )) ||
-	    
-	    (tag[0] == 'o' && !strcmp(tag,"ol")
-	     && ((attrName[0] == 'r' && !strcmp(attrName,"reversed"))
-		 )) ||
-	    
-	    (tag[0] == 'o' && !strcmp(tag,"optgroup")
-	     && ((attrName[0] == 'd' && !strcmp(attrName,"disabled"))
-		 )) ||
-	    
-	    (tag[0] == 'o' && !strcmp(tag,"option")
-	     && ((attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
-		 (attrName[0] == 's' && !strcmp(attrName,"selected"))
-		 )) ||
-
-	    (tag[0] == 's' && !strcmp(tag,"script")
-	    && ((attrName[0] == 'a' && !strcmp(attrName,"async")) ||
-		(attrName[0] == 'd' && !strcmp(attrName,"defer"))
-		)) ||
-
-	    (tag[0] == 's' && !strcmp(tag,"select")
-	    && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
-		(attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
-		(attrName[0] == 'm' && !strcmp(attrName,"multiple")) ||
-		(attrName[0] == 'r' && !strcmp(attrName,"required"))
-		)) ||
-
-	    (tag[0] == 's' && !strcmp(tag,"style")
-	    && ((attrName[0] == 's' && !strcmp(attrName,"scoped"))
-		)) ||
-
-	    (tag[0] == 't' && !strcmp(tag,"textarea")
-	    && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
-		(attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
-		(attrName[0] == 'r' && !strcmp(attrName,"readonly")) ||
-		(attrName[0] == 'r' && !strcmp(attrName,"required"))
-		)) ||
-
-	    (tag[0] == 't' && !strcmp(tag,"time")
-	    && ((attrName[0] == 'p' && !strcmp(attrName,"pubdate"))
-		)) ||
-	    
-	    (tag[0] == 'a' && !strcmp(tag,"audio")
-	    && ((attrName[0] == 'a' && !strcmp(attrName,"autoplay")) ||
-		(attrName[0] == 'c' && !strcmp(attrName,"controls")) ||
-		(attrName[0] == 'l' && !strcmp(attrName,"loop"))
-		)) ||
-	    (tag[0] == 'v' && !strcmp(tag,"video")
-	    && ((attrName[0] == 'a' && !strcmp(attrName,"autoplay")) ||
-		(attrName[0] == 'c' && !strcmp(attrName,"controls")) ||
-		(attrName[0] == 'l' && !strcmp(attrName,"loop"))
-		))
-	    ) {
-	    /* we have a boolean attrubute */
+	if (tcldom_isBooleanAttributeHTML(tag, attrName)) {
+	    /* we have a boolean attribute */
 	    int boolValue = 0;
 	    Tcl_GetBooleanFromObj(interp, Tcl_NewStringObj(attrs->nodeValue, -1), &boolValue);
 	    writeAttrName = boolValue;
 	    writeAttrValue = 0;
-	    fprintf(stderr, "=== we have boolean attr %s %d %d\n",attrName, writeAttrName, writeAttrValue);
-
+	} else {
+	    writeAttrName = 1;
+	    writeAttrValue = 1;
 	}
         if (writeAttrName) {
 	    writeChars (htmlString, chan, attrName, -1);

--- a/generic/tcldom.c
+++ b/generic/tcldom.c
@@ -2663,19 +2663,34 @@ void tcldom_treeAsHTML (
         int writeAttrName, writeAttrValue;
 
         tcldom_tolower(attrs->nodeName, attrName, 80);
-        writeChars(htmlString, chan, " ", 1);
 
 	if (tcldom_isBooleanAttributeHTML(tag, attrName)) {
-	    /* we have a boolean attribute */
+	    /* We have a boolean attribute */
 	    int boolValue = 0;
-	    Tcl_GetBooleanFromObj(interp, Tcl_NewStringObj(attrs->nodeValue, -1), &boolValue);
+	    if (*attrs->nodeValue == '\0' ||
+		!strcmp(attrs->nodeValue,attrName)) {
+	      /* HTML 5 allows empty nodeValue or nodeValue eq attrName for true */
+	      boolValue = 1;
+	    } else {
+	      /*-----------------------------------------------------------
+	       | Check boolean value. If the boolean conversion
+	       | fails, Tcl leaves the error message in the interp
+	       | result, which has to be cleared.
+	       \----------------------------------------------------------*/
+	      int result = Tcl_GetBooleanFromObj(interp, Tcl_NewStringObj(attrs->nodeValue, -1), &boolValue);
+	      if (result != TCL_OK) {
+		Tcl_ResetResult(interp);
+	      }
+	    }
 	    writeAttrName = boolValue;
 	    writeAttrValue = 0;
 	} else {
 	    writeAttrName = 1;
 	    writeAttrValue = 1;
 	}
+
         if (writeAttrName) {
+	    writeChars(htmlString, chan, " ", 1);
 	    writeChars (htmlString, chan, attrName, -1);
 	}
         if (writeAttrValue) {

--- a/generic/tcldom.c
+++ b/generic/tcldom.c
@@ -2428,6 +2428,7 @@ static
 void tcldom_treeAsHTML (
     Tcl_Obj     *htmlString,
     domNode     *node,
+    Tcl_Interp  *interp,
     Tcl_Channel  chan,
     int          escapeNonASCII,
     int          htmlEntities,
@@ -2471,7 +2472,7 @@ void tcldom_treeAsHTML (
         }
         child = doc->rootNode->firstChild;
         while (child) {
-            tcldom_treeAsHTML(htmlString, child, chan, escapeNonASCII,
+	    tcldom_treeAsHTML(htmlString, child, interp, chan, escapeNonASCII,
                               htmlEntities, doctypeDeclaration, 0);
             child = child->nextSibling;
         }
@@ -2558,13 +2559,120 @@ void tcldom_treeAsHTML (
 
     attrs = node->firstAttr;
     while (attrs) {
+        int writeAttrName = 1;
+        int writeAttrValue = 1;
         tcldom_tolower(attrs->nodeName, attrName, 80);
         writeChars(htmlString, chan, " ", 1);
-        writeChars (htmlString, chan, attrName, -1);
-        writeChars(htmlString, chan, "=\"", 2);
-        tcldom_AppendEscaped(htmlString, chan, attrs->nodeValue, -1, 1,
-                             escapeNonASCII, htmlEntities, 0);
-        writeChars(htmlString, chan, "\"", 1);
+
+	fprintf(stderr, "=== we have tag %s and attr %s\n",tag,attrName);
+
+	if (
+	    (tag[0] == 'b' && !strcmp(tag,"button")
+	    && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
+		(attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
+		(attrName[0] == 'f' && !strcmp(attrName,"formnovalidate"))
+		)) ||
+
+	    (tag[0] == 'c' && !strcmp(tag,"command")
+	    && ((attrName[0] == 'c' && !strcmp(attrName,"checked")) ||
+		(attrName[0] == 'd' && !strcmp(attrName,"disabled"))
+		)) ||
+
+	    (tag[0] == 'f' && !strcmp(tag,"form")
+	    && ((attrName[0] == 'n' && !strcmp(attrName,"novalidate"))
+		)) ||
+
+	    (tag[0] == 'i' && !strcmp(tag,"img")
+	    && ((attrName[0] == 'i' && !strcmp(attrName,"ismap"))
+		)) ||
+
+	    (tag[0] == 'i' && !strcmp(tag,"iframe")
+	    && ((attrName[0] == 's' && !strcmp(attrName,"seamless"))
+		)) ||
+
+	    (tag[0] == 'i' && !strcmp(tag,"input")
+	     && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
+		 (attrName[0] == 'c' && !strcmp(attrName,"checked")) ||
+		 (attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
+		 (attrName[0] == 'f' && !strcmp(attrName,"formnovalidate")) ||
+		 (attrName[0] == 'm' && !strcmp(attrName,"multiple")) ||
+		 (attrName[0] == 'r' && !strcmp(attrName,"readonly")) ||
+		 (attrName[0] == 'r' && !strcmp(attrName,"required"))
+		 )) ||
+
+	    (tag[0] == 'k' && !strcmp(tag,"keygen")
+	     && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
+		 (attrName[0] == 'd' && !strcmp(attrName,"disabled"))
+		 )) ||
+	    
+	    (tag[0] == 'o' && !strcmp(tag,"ol")
+	     && ((attrName[0] == 'r' && !strcmp(attrName,"reversed"))
+		 )) ||
+	    
+	    (tag[0] == 'o' && !strcmp(tag,"optgroup")
+	     && ((attrName[0] == 'd' && !strcmp(attrName,"disabled"))
+		 )) ||
+	    
+	    (tag[0] == 'o' && !strcmp(tag,"option")
+	     && ((attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
+		 (attrName[0] == 's' && !strcmp(attrName,"selected"))
+		 )) ||
+
+	    (tag[0] == 's' && !strcmp(tag,"script")
+	    && ((attrName[0] == 'a' && !strcmp(attrName,"async")) ||
+		(attrName[0] == 'd' && !strcmp(attrName,"defer"))
+		)) ||
+
+	    (tag[0] == 's' && !strcmp(tag,"select")
+	    && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
+		(attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
+		(attrName[0] == 'm' && !strcmp(attrName,"multiple")) ||
+		(attrName[0] == 'r' && !strcmp(attrName,"required"))
+		)) ||
+
+	    (tag[0] == 's' && !strcmp(tag,"style")
+	    && ((attrName[0] == 's' && !strcmp(attrName,"scoped"))
+		)) ||
+
+	    (tag[0] == 't' && !strcmp(tag,"textarea")
+	    && ((attrName[0] == 'a' && !strcmp(attrName,"autofocus")) ||
+		(attrName[0] == 'd' && !strcmp(attrName,"disabled")) ||
+		(attrName[0] == 'r' && !strcmp(attrName,"readonly")) ||
+		(attrName[0] == 'r' && !strcmp(attrName,"required"))
+		)) ||
+
+	    (tag[0] == 't' && !strcmp(tag,"time")
+	    && ((attrName[0] == 'p' && !strcmp(attrName,"pubdate"))
+		)) ||
+	    
+	    (tag[0] == 'a' && !strcmp(tag,"audio")
+	    && ((attrName[0] == 'a' && !strcmp(attrName,"autoplay")) ||
+		(attrName[0] == 'c' && !strcmp(attrName,"controls")) ||
+		(attrName[0] == 'l' && !strcmp(attrName,"loop"))
+		)) ||
+	    (tag[0] == 'v' && !strcmp(tag,"video")
+	    && ((attrName[0] == 'a' && !strcmp(attrName,"autoplay")) ||
+		(attrName[0] == 'c' && !strcmp(attrName,"controls")) ||
+		(attrName[0] == 'l' && !strcmp(attrName,"loop"))
+		))
+	    ) {
+	    /* we have a boolean attrubute */
+	    int boolValue = 0;
+	    Tcl_GetBooleanFromObj(interp, Tcl_NewStringObj(attrs->nodeValue, -1), &boolValue);
+	    writeAttrName = boolValue;
+	    writeAttrValue = 0;
+	    fprintf(stderr, "=== we have boolean attr %s %d %d\n",attrName, writeAttrName, writeAttrValue);
+
+	}
+        if (writeAttrName) {
+	    writeChars (htmlString, chan, attrName, -1);
+	}
+        if (writeAttrValue) {
+	    writeChars(htmlString, chan, "=\"", 2);
+            tcldom_AppendEscaped(htmlString, chan, attrs->nodeValue, -1, 1,
+				 escapeNonASCII, htmlEntities, 0);
+	    writeChars(htmlString, chan, "\"", 1);
+	}
         attrs = attrs->nextSibling;
     }
     writeChars(htmlString, chan, ">", 1);
@@ -2574,7 +2682,7 @@ void tcldom_treeAsHTML (
         /* strange ! should not happen ! */
         child = node->firstChild;
         while (child != NULL) {
-            tcldom_treeAsHTML(htmlString, child, chan, escapeNonASCII,
+	    tcldom_treeAsHTML(htmlString, child, interp, chan, escapeNonASCII,
                               htmlEntities, doctypeDeclaration, scriptTag);
             child = child->nextSibling;
         }
@@ -2588,7 +2696,7 @@ void tcldom_treeAsHTML (
             writeChars(htmlString, chan, "\n", 1);
         }
         while (child != NULL) {
-            tcldom_treeAsHTML(htmlString, child, chan, escapeNonASCII,
+	    tcldom_treeAsHTML(htmlString, child, interp, chan, escapeNonASCII,
                                htmlEntities, doctypeDeclaration, scriptTag);
             child = child->nextSibling;
         }
@@ -3112,7 +3220,7 @@ static int serializeAsHTML (
         }
     }
     resultPtr = Tcl_NewStringObj("", 0);
-    tcldom_treeAsHTML(resultPtr, node, chan, escapeNonASCII, htmlEntities,
+    tcldom_treeAsHTML(resultPtr, node, interp, chan, escapeNonASCII, htmlEntities,
                       doctypeDeclaration, 0);
     Tcl_AppendResult(interp, Tcl_GetString(resultPtr), NULL);
     Tcl_DecrRefCount(resultPtr);

--- a/generic/tcldom.c
+++ b/generic/tcldom.c
@@ -6068,7 +6068,7 @@ int tcldom_EvalLocked (
     if (ret == TCL_ERROR) {
         char msg[64 + TCL_INTEGER_SPACE];
         sprintf(msg, "\n    (\"%s %s\" body line %d)", Tcl_GetString(objv[0]),
-                Tcl_GetString(objv[1]), interp->errorLine);
+                Tcl_GetString(objv[1]), Tcl_GetErrorLine(interp));
         Tcl_AddErrorInfo(interp, msg);
     }
 

--- a/generic/tcldom.h
+++ b/generic/tcldom.h
@@ -72,6 +72,10 @@ Tcl_ObjCmdProc TclTdomObjCmd;
 EXTERN int Tdom_Init     _ANSI_ARGS_((Tcl_Interp *interp));
 EXTERN int Tdom_SafeInit _ANSI_ARGS_((Tcl_Interp *interp));
 
+#if (TCL_MAJOR_VERSION == 8) && (TCL_MINOR_VERSION < 6) || (TCL_MAJOR_VERSION > 8)
+# define Tcl_GetErrorLine(interp) (interp)->errorLine
+#endif
+
 #endif
 
 


### PR DESCRIPTION
This pull request contains essentially the following changes:
- provide compatibility with Tcl 8.6
- fixed wrong size on memcpy on 64 bit (when sizeof(int)!=sizeof(int*))
- provide support for boolean HTML attributes to follow recommended output conventions in HTML5
